### PR TITLE
Updating to 1.0.8

### DIFF
--- a/__test__/interpreter/interpreter.test.ts
+++ b/__test__/interpreter/interpreter.test.ts
@@ -4,7 +4,7 @@ dotenv.config();
 import { BabelProxyService } from '../../src';
 
 describe('Interpreter Module Test Suite', () => {
-  const apiKey = process.env.SAMPLE_API_KEY ?? '';
+  const apiKey = process.env.SAMPLE_API_KEY || '';
 
   it("List translation to 'es_CL' ", async () => {
     const request = [
@@ -40,3 +40,4 @@ describe('Interpreter Module Test Suite', () => {
     expect(result.length).toBe(Object.values(dictionary).length);
   });
 });
+

--- a/__test__/interpreter/interpreter.test.ts
+++ b/__test__/interpreter/interpreter.test.ts
@@ -27,9 +27,8 @@ describe('Interpreter Module Test Suite', () => {
 
   it("Dictionary translation to 'pt_BR' ", async () => {
     const dictionary = {
-      titleLabel: 'appointment-document.bioSigns.titleLabel',
-      messageTitle:
-        'messagingText.TEXT.sendCrossAppointmentAddComment.messageTitle',
+      titleLabel: 'prescription-types.PRESCRIPTION',
+      messageTitle: 'register-title',
     };
 
     const babel = new BabelProxyService({

--- a/__test__/messaging/messaging.test.ts
+++ b/__test__/messaging/messaging.test.ts
@@ -4,7 +4,7 @@ dotenv.config();
 import { BabelProxyService } from '../../src';
 
 describe('Messaging Module Test Suite', () => {
-  const apiKey = process.env.SAMPLE_API_KEY ?? '';
+  const apiKey = process.env.SAMPLE_API_KEY || '';
 
   it("Valid messaging result from 'es_ES' ", async () => {
     const messaging = {
@@ -21,3 +21,4 @@ describe('Messaging Module Test Suite', () => {
     expect(result.httpCode).not.toBe(undefined);
   });
 });
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atrysglobal/babel-ripper",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Conjunto de herramientas de interfaz y tipado estricto para acceder a servicio de traducciones unificado BABEL.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atrysglobal/babel-ripper",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Conjunto de herramientas de interfaz y tipado estricto para acceder a servicio de traducciones unificado BABEL.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/babel-proxy/enums.ts
+++ b/src/babel-proxy/enums.ts
@@ -4,7 +4,7 @@
  *
  */
 export enum ALLOWED_HEADERS {
-  LOCALE = 'Locale-Target',
+  LOCALE = 'locale',
   API_KEY = 'X-Api-Key',
 }
 

--- a/src/babel-proxy/index.ts
+++ b/src/babel-proxy/index.ts
@@ -70,7 +70,7 @@ export default class BabelProxyService implements IBabelService {
     }
 
     this.httpInstance = BabelProxyHttp.getInstance(options.apiKey);
-    this.serviceUrl = BabelProxyHttp.getInstanceConfig().baseURL ?? '';
+    this.serviceUrl = BabelProxyHttp.getInstanceConfig().baseURL || '';
 
     this.defaultLocale =
       options && options.defaultLocale?.length
@@ -112,7 +112,7 @@ export default class BabelProxyService implements IBabelService {
     try {
       const transactionConfig = {
         headers: {
-          [ALLOWED_HEADERS.LOCALE]: options?.locale ?? this.defaultLocale,
+          [ALLOWED_HEADERS.LOCALE]: options?.locale || this.defaultLocale,
         },
       };
 
@@ -150,7 +150,7 @@ export default class BabelProxyService implements IBabelService {
     try {
       const transactionConfig = {
         headers: {
-          [ALLOWED_HEADERS.LOCALE]: options?.locale ?? this.defaultLocale,
+          [ALLOWED_HEADERS.LOCALE]: options?.locale || this.defaultLocale,
         },
       };
 

--- a/src/babel-proxy/libs/http.lib.ts
+++ b/src/babel-proxy/libs/http.lib.ts
@@ -4,7 +4,7 @@ import { ALLOWED_HEADERS } from '../enums';
 const defaultAddress =
   'https://dev.services.telemedicina.com/translations/interpreter';
 
-const BABEL_ADDRESS = process.env.BABEL_SERVICE ?? defaultAddress;
+const BABEL_ADDRESS = process.env.BABEL_SERVICE || defaultAddress;
 const BABEL_TIMEOUT = 5000;
 export abstract class BabelProxyHttp {
   static getInstanceConfig(): AxiosRequestConfig {

--- a/src/babel-ripper/index.ts
+++ b/src/babel-ripper/index.ts
@@ -10,7 +10,7 @@ export class BabelRipper {
     return (
       this.translations.find((el) =>
         typeof input === 'string' ? el.id === input : el.id === input.target,
-      )?.message ?? ''
+      )?.message || ''
     );
   }
 
@@ -20,7 +20,7 @@ export class BabelRipper {
         typeof input === 'string'
           ? el.message === input
           : el.message === input.message,
-      )?.id ?? ''
+      )?.id || ''
     );
   }
 }


### PR DESCRIPTION
Se reemplaza el header 'Target-Locale' hacia 'locale' en los diccionarios de cabeceras de consulta hacia el microservicio de babel. Además se añaden mejoras (downgrade) hacia versión 14.x de nodeJS para asegurar su funcionamiento en entornos de AWS Lambda.

Se incluyen versiones 1.0.7 & 1.0.8.